### PR TITLE
選択ずみの画像は一覧/入力画面でリストの行ごとに管理する、選択済みの画像があれば表示する

### DIFF
--- a/StokManagementApp/StokManagementApp/Base.lproj/Main.storyboard
+++ b/StokManagementApp/StokManagementApp/Base.lproj/Main.storyboard
@@ -16,44 +16,27 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="数量9,999" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fzf-Vy-cBa">
-                                <rect key="frame" x="20" y="79" width="149" height="39"/>
+                                <rect key="frame" x="20" y="47" width="149" height="40"/>
                                 <fontDescription key="fontDescription" name=".SFNS-Regular" family=".AppleSystemUIFont" pointSize="35"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="9999" translatesAutoresizingMaskIntoConstraints="NO" id="e9C-ya-j27">
-                                <rect key="frame" x="308" y="86" width="94" height="32"/>
-                                <connections>
-                                    <action selector="actionChangeAmountButton:" destination="BYZ-38-t0r" eventType="valueChanged" id="Ddj-bO-nhG"/>
-                                </connections>
-                            </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kq5-CK-tjQ">
-                                <rect key="frame" x="20" y="137" width="149" height="42"/>
+                                <rect key="frame" x="20" y="91" width="149" height="42"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="35"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="comment" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="k03-ZR-gKe">
-                                <rect key="frame" x="177" y="141" width="145" height="34"/>
+                                <rect key="frame" x="177" y="95" width="217" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <textInputTraits key="textInputTraits"/>
                                 <connections>
                                     <action selector="commentText:" destination="BYZ-38-t0r" eventType="valueChanged" id="Jx1-cB-5X8"/>
                                 </connections>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YGc-dV-fmx">
-                                <rect key="frame" x="332" y="143" width="70" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="70" id="goV-6s-Kr7"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
-                                <state key="normal" title="追加"/>
-                                <connections>
-                                    <action selector="actionAddAmountButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rBZ-xn-Sxa"/>
-                                </connections>
-                            </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ySA-Dc-z9q">
-                                <rect key="frame" x="20" y="187" width="374" height="634"/>
+                                <rect key="frame" x="20" y="141" width="374" height="680"/>
                                 <color key="sectionIndexBackgroundColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="amountCell1" id="ehq-9w-zJv">
@@ -83,14 +66,14 @@
                                 </connections>
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nNJ-Z5-nYR">
-                                <rect key="frame" x="156" y="829" width="238" height="44"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
+                                <rect key="frame" x="164" y="829" width="238" height="44"/>
+                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="26"/>
                                 <state key="normal" title="選択された合計数量"/>
                                 <connections>
                                     <action selector="actionShowSelectedTotalValueButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="eOk-AN-es1"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2bc-IU-hDr">
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2bc-IU-hDr">
                                 <rect key="frame" x="20" y="829" width="80" height="44"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="26"/>
                                 <state key="normal" title="クリア"/>
@@ -98,30 +81,50 @@
                                     <action selector="actionAmountClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5Ac-UO-TbF"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YGc-dV-fmx">
+                                <rect key="frame" x="341" y="42" width="53" height="44"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
+                                <state key="normal" title="追加"/>
+                                <connections>
+                                    <action selector="actionAddAmountButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rBZ-xn-Sxa"/>
+                                </connections>
+                            </button>
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="9999" translatesAutoresizingMaskIntoConstraints="NO" id="e9C-ya-j27">
+                                <rect key="frame" x="208" y="51" width="94" height="32"/>
+                                <connections>
+                                    <action selector="actionChangeAmountButton:" destination="BYZ-38-t0r" eventType="valueChanged" id="Ddj-bO-nhG"/>
+                                </connections>
+                            </stepper>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="k03-ZR-gKe" firstAttribute="centerY" secondItem="YGc-dV-fmx" secondAttribute="centerY" id="0cr-vb-vYZ"/>
-                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="2jJ-bG-Vep"/>
-                            <constraint firstItem="2bc-IU-hDr" firstAttribute="baseline" secondItem="nNJ-Z5-nYR" secondAttribute="baseline" id="5KT-sj-ejy"/>
-                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="leading" secondItem="2bc-IU-hDr" secondAttribute="leading" id="A4U-fB-uJ2"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="e9C-ya-j27" secondAttribute="trailing" constant="12" id="HwC-bw-tZY"/>
-                            <constraint firstItem="k03-ZR-gKe" firstAttribute="top" secondItem="e9C-ya-j27" secondAttribute="bottom" constant="23" id="IsM-wS-1j0"/>
-                            <constraint firstItem="YGc-dV-fmx" firstAttribute="leading" secondItem="k03-ZR-gKe" secondAttribute="trailing" constant="10" id="NoB-5Y-Qpe"/>
-                            <constraint firstAttribute="bottomMargin" secondItem="2bc-IU-hDr" secondAttribute="bottom" constant="-11" id="RUv-Ok-mNd"/>
-                            <constraint firstItem="2bc-IU-hDr" firstAttribute="top" secondItem="ySA-Dc-z9q" secondAttribute="bottom" constant="8" id="SwL-KN-KDm"/>
-                            <constraint firstItem="YGc-dV-fmx" firstAttribute="trailing" secondItem="e9C-ya-j27" secondAttribute="trailing" id="Txt-1G-9sH"/>
-                            <constraint firstItem="kq5-CK-tjQ" firstAttribute="top" secondItem="fzf-Vy-cBa" secondAttribute="bottom" constant="19" id="Vbs-Yd-RZ5"/>
-                            <constraint firstItem="k03-ZR-gKe" firstAttribute="leading" secondItem="kq5-CK-tjQ" secondAttribute="trailing" constant="8" symbolic="YES" id="adc-yo-LRo"/>
-                            <constraint firstItem="fzf-Vy-cBa" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="f5g-Wy-cpd"/>
-                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="leading" secondItem="kq5-CK-tjQ" secondAttribute="leading" id="fT4-MJ-vbR"/>
-                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="top" secondItem="kq5-CK-tjQ" secondAttribute="bottom" constant="8" id="gaP-9N-v64"/>
-                            <constraint firstItem="e9C-ya-j27" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="42" id="kUF-2f-fZR"/>
-                            <constraint firstItem="fzf-Vy-cBa" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="35" id="mTS-Yy-DiH"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="k03-ZR-gKe" secondAttribute="bottom" constant="687" id="qkV-pJ-QDQ"/>
-                            <constraint firstItem="kq5-CK-tjQ" firstAttribute="leading" secondItem="fzf-Vy-cBa" secondAttribute="leading" id="v3C-GW-oVU"/>
-                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="trailing" secondItem="nNJ-Z5-nYR" secondAttribute="trailing" id="zcS-Pz-fsY"/>
-                            <constraint firstItem="YGc-dV-fmx" firstAttribute="top" secondItem="e9C-ya-j27" secondAttribute="bottom" constant="25" id="zca-lo-Vf1"/>
+                            <constraint firstItem="k03-ZR-gKe" firstAttribute="leading" secondItem="kq5-CK-tjQ" secondAttribute="trailing" constant="8" id="20E-v5-P6l"/>
+                            <constraint firstItem="k03-ZR-gKe" firstAttribute="top" secondItem="YGc-dV-fmx" secondAttribute="bottom" constant="9" id="2kp-9J-GVv"/>
+                            <constraint firstItem="2bc-IU-hDr" firstAttribute="leading" secondItem="kq5-CK-tjQ" secondAttribute="leading" id="3AO-RJ-u1I"/>
+                            <constraint firstItem="e9C-ya-j27" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="7" id="4zS-TR-ZKa"/>
+                            <constraint firstItem="e9C-ya-j27" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fzf-Vy-cBa" secondAttribute="trailing" constant="8" symbolic="YES" id="5yy-kU-UoM"/>
+                            <constraint firstAttribute="bottom" secondItem="2bc-IU-hDr" secondAttribute="bottom" constant="23" id="6dC-sX-aGs"/>
+                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="top" secondItem="kq5-CK-tjQ" secondAttribute="bottom" constant="8" id="9ZO-cq-tZU"/>
+                            <constraint firstItem="2bc-IU-hDr" firstAttribute="leading" secondItem="fzf-Vy-cBa" secondAttribute="leading" id="DjY-C8-bUI"/>
+                            <constraint firstItem="YGc-dV-fmx" firstAttribute="centerY" secondItem="fzf-Vy-cBa" secondAttribute="centerY" constant="-3" id="FvQ-Se-7XH"/>
+                            <constraint firstItem="k03-ZR-gKe" firstAttribute="top" secondItem="e9C-ya-j27" secondAttribute="bottom" constant="12" id="H8Y-X6-7ks"/>
+                            <constraint firstItem="kq5-CK-tjQ" firstAttribute="top" secondItem="fzf-Vy-cBa" secondAttribute="bottom" constant="4" id="H9J-hj-QYx"/>
+                            <constraint firstItem="2bc-IU-hDr" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="Mmx-HJ-41w"/>
+                            <constraint firstItem="kq5-CK-tjQ" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="91" id="P2q-5N-7Ew"/>
+                            <constraint firstItem="YGc-dV-fmx" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="-2" id="P46-9h-McI"/>
+                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="trailing" secondItem="k03-ZR-gKe" secondAttribute="trailing" id="Ptf-ku-rhi"/>
+                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="R7E-oL-0E3"/>
+                            <constraint firstAttribute="bottomMargin" secondItem="2bc-IU-hDr" secondAttribute="bottom" constant="-11" id="U9V-hi-Dgc"/>
+                            <constraint firstAttribute="bottom" secondItem="nNJ-Z5-nYR" secondAttribute="bottom" constant="23" id="WHX-Xm-pKA"/>
+                            <constraint firstItem="2bc-IU-hDr" firstAttribute="leading" secondItem="ySA-Dc-z9q" secondAttribute="leading" id="YKG-x6-yl9"/>
+                            <constraint firstItem="YGc-dV-fmx" firstAttribute="leading" secondItem="e9C-ya-j27" secondAttribute="trailing" constant="39" id="aHP-pM-ooE"/>
+                            <constraint firstItem="ySA-Dc-z9q" firstAttribute="trailing" secondItem="YGc-dV-fmx" secondAttribute="trailing" id="b1W-vD-hdw"/>
+                            <constraint firstItem="2bc-IU-hDr" firstAttribute="baseline" secondItem="nNJ-Z5-nYR" secondAttribute="baseline" id="bMf-Hc-HKJ"/>
+                            <constraint firstItem="nNJ-Z5-nYR" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="2bc-IU-hDr" secondAttribute="trailing" constant="8" symbolic="YES" id="bW1-Dw-jEP"/>
+                            <constraint firstItem="kq5-CK-tjQ" firstAttribute="centerY" secondItem="k03-ZR-gKe" secondAttribute="centerY" id="flu-vi-sh4"/>
+                            <constraint firstItem="2bc-IU-hDr" firstAttribute="top" secondItem="ySA-Dc-z9q" secondAttribute="bottom" constant="8" id="p6u-P3-Jzf"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="nNJ-Z5-nYR" secondAttribute="trailing" constant="12" id="qoP-PF-4oH"/>
+                            <constraint firstItem="e9C-ya-j27" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="7" id="rQh-rD-vDi"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
@@ -149,41 +152,56 @@
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PRb-bb-DQX">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="4nG-dS-eYE"/>
+                                    <constraint firstAttribute="width" secondItem="PRb-bb-DQX" secondAttribute="height" multiplier="207:22" id="YLw-xk-isK"/>
                                 </constraints>
                                 <items>
                                     <navigationItem title="Title" id="brN-2R-Dxj"/>
                                 </items>
                             </navigationBar>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rsW-ia-6ft">
-                                <rect key="frame" x="0.0" y="44" width="414" height="754"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rsW-ia-6ft">
+                                <rect key="frame" x="0.0" y="56" width="414" height="698"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="rsW-ia-6ft" secondAttribute="height" multiplier="207:349" id="oCW-Jl-8td"/>
+                                </constraints>
                             </imageView>
-                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LXL-1x-84T">
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LXL-1x-84T">
                                 <rect key="frame" x="0.0" y="754" width="414" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="LXL-1x-84T" secondAttribute="height" multiplier="207:22" id="krB-wn-LU4"/>
+                                </constraints>
                                 <items>
                                     <barButtonItem systemItem="add" id="HWm-93-M0w">
                                         <connections>
                                             <action selector="actionSelectImageButton:" destination="GOo-1x-gQM" id="bo5-lh-0Gq"/>
                                         </connections>
                                     </barButtonItem>
-                                    <barButtonItem width="42" systemItem="fixedSpace" id="gpA-5r-Pmy"/>
-                                    <barButtonItem width="42" systemItem="fixedSpace" id="d7G-e7-r9x"/>
-                                    <barButtonItem width="42" systemItem="fixedSpace" id="fS6-wY-20U"/>
-                                    <barButtonItem systemItem="save" id="k30-5I-hKZ"/>
-                                    <barButtonItem width="42" systemItem="fixedSpace" id="0GT-5p-xZR"/>
-                                    <barButtonItem width="42" systemItem="fixedSpace" id="GFd-Nv-LgJ"/>
-                                    <barButtonItem width="42" systemItem="fixedSpace" id="CqY-ip-vxE"/>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="uFl-7q-9bv"/>
+                                    <barButtonItem systemItem="save" id="k30-5I-hKZ">
+                                        <connections>
+                                            <action selector="actionSaveImageButton:" destination="GOo-1x-gQM" id="8ou-4n-JN2"/>
+                                        </connections>
+                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="4tP-Cu-atZ"/>
                                     <barButtonItem systemItem="trash" id="fbp-kV-prA"/>
                                 </items>
                             </toolbar>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="PRb-bb-DQX" firstAttribute="centerX" secondItem="tne-PO-jag" secondAttribute="centerX" id="1Er-Jz-p7C"/>
-                            <constraint firstItem="PRb-bb-DQX" firstAttribute="leading" secondItem="Pa8-hY-pnp" secondAttribute="leading" id="FNU-2K-q4o"/>
-                            <constraint firstItem="PRb-bb-DQX" firstAttribute="top" secondItem="Pa8-hY-pnp" secondAttribute="top" id="ySw-r1-EH5"/>
+                            <constraint firstItem="PRb-bb-DQX" firstAttribute="trailing" secondItem="Pa8-hY-pnp" secondAttribute="trailing" id="0wI-WD-EIr"/>
+                            <constraint firstItem="rsW-ia-6ft" firstAttribute="trailing" secondItem="Pa8-hY-pnp" secondAttribute="trailing" id="31V-Qg-gOF"/>
+                            <constraint firstItem="rsW-ia-6ft" firstAttribute="top" secondItem="PRb-bb-DQX" secondAttribute="bottom" constant="12" id="6QV-mJ-gCN"/>
+                            <constraint firstItem="LXL-1x-84T" firstAttribute="trailing" secondItem="Pa8-hY-pnp" secondAttribute="trailing" id="9jd-DP-IWo"/>
+                            <constraint firstItem="PRb-bb-DQX" firstAttribute="trailing" secondItem="LXL-1x-84T" secondAttribute="trailing" id="Cyx-R4-9zm"/>
+                            <constraint firstItem="rsW-ia-6ft" firstAttribute="centerX" secondItem="tne-PO-jag" secondAttribute="centerX" id="Jyw-WA-Gv2"/>
+                            <constraint firstItem="LXL-1x-84T" firstAttribute="top" secondItem="rsW-ia-6ft" secondAttribute="bottom" id="Q06-ek-qf0"/>
+                            <constraint firstItem="PRb-bb-DQX" firstAttribute="top" secondItem="Pa8-hY-pnp" secondAttribute="top" id="aQX-vS-nKe"/>
+                            <constraint firstItem="LXL-1x-84T" firstAttribute="centerX" secondItem="tne-PO-jag" secondAttribute="centerX" id="aaB-wb-JPp"/>
+                            <constraint firstItem="PRb-bb-DQX" firstAttribute="leading" secondItem="LXL-1x-84T" secondAttribute="leading" id="bIg-cm-4dd"/>
+                            <constraint firstItem="PRb-bb-DQX" firstAttribute="leading" secondItem="Pa8-hY-pnp" secondAttribute="leading" id="v5A-s1-pnR"/>
+                            <constraint firstItem="LXL-1x-84T" firstAttribute="leading" secondItem="Pa8-hY-pnp" secondAttribute="leading" id="vRd-HB-Qub"/>
+                            <constraint firstItem="Pa8-hY-pnp" firstAttribute="bottom" secondItem="LXL-1x-84T" secondAttribute="bottom" constant="10" id="wrO-lH-5ZI"/>
+                            <constraint firstItem="rsW-ia-6ft" firstAttribute="leading" secondItem="Pa8-hY-pnp" secondAttribute="leading" id="zvR-Yq-TdL"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Pa8-hY-pnp"/>
                     </view>
@@ -191,6 +209,7 @@
                     <connections>
                         <outlet property="UiNavigationItem" destination="brN-2R-Dxj" id="WLh-Ou-CYa"/>
                         <outlet property="imageView" destination="rsW-ia-6ft" id="oS0-fV-69x"/>
+                        <outlet property="uiNavigationItem" destination="brN-2R-Dxj" id="Wuz-2w-ZGN"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FPr-cx-7Q8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/StokManagementApp/StokManagementApp/DetailViewController.swift
+++ b/StokManagementApp/StokManagementApp/DetailViewController.swift
@@ -70,22 +70,19 @@ class DetailViewController : UIViewController {
     //写真を保存する為のactionSaveImageButton
     @IBAction private func actionSaveImageButton(_ sender: Any) {
         //現在表示中の画像データを取得
-        let image = imageView.image
-        
-        //imageが空の場合には後続処理を継続しない
-        guard let thisImage = image else {
+        //imageView.imageが空の場合には後続処理を継続しない
+        guard let thisImage = imageView.image else {
             return
         }
-        
-        let imageData = thisImage.pngData()
-        
+                
         //imageRowが空の場合には後続処理を継続しない
         guard let thisImageRow = imageRow else {
             return
         }
         
         let stringImageRow = convertString(thisImageRow)
-        
+        let imageData = thisImage.pngData()
+
         //Keyに受け取ったRow、Valueに写真を指定して本体に収納
         userDefaults.setValue(imageData, forKey: stringImageRow)
         userDefaults.synchronize()

--- a/StokManagementApp/StokManagementApp/DetailViewController.swift
+++ b/StokManagementApp/StokManagementApp/DetailViewController.swift
@@ -16,8 +16,12 @@ class DetailViewController : UIViewController {
     @IBOutlet private weak var imageView: UIImageView!
     
     //MARK: - instance
-    //titleTextにViewControllerから受け取ったamountArrayのテキストを表示
+    //titleTextに受け取ったamountArrayのテキストを表示
     var titleText: String?
+    //詳細が押下されたセルのIndexPath
+    var imageRow: Int?
+    //写真を保存しておく為のuserDefaults
+    let userDefaults = UserDefaults.standard
 
     //MARK: - public method
     override func viewDidLoad() {
@@ -31,11 +35,61 @@ class DetailViewController : UIViewController {
         
         //titleにtextの内容を代入して表示
         uiNavigationItem.title = thisTitleText
+        
+        //imageRowに値が入っていない場合には、後続処理を継続しない
+        guard let thisImageRow = imageRow else {
+            return
+        }
+        
+        //行番号thisImageRowをKeyとして使用するためにStringに変換
+        let stringImageRow = convertString(thisImageRow)
 
+        //詳細ボタンが押下されたセルに写真が保存されていた場合にはimageViewに保存してある写真を表示
+        if userDefaults.object(forKey: stringImageRow) != nil {
+            let canNotShowImage = userDefaults.data(forKey: stringImageRow)
+            
+            //rowImageDataが空の場合には、後続処理を継続しない
+            guard let thisCanNotShowImage = canNotShowImage else {
+                return
+            }
+            
+            //Data型をUIImage型に変換
+            let canShowImage = UIImage(data: thisCanNotShowImage)
+            imageView.image = canShowImage
+        }
+    }
+    
+    //MARK: - private method
+    
+    private func convertString(_ to: Int) -> String {
+        return String(to)
     }
     
     //MARK: - IBAction
     
+    //写真を保存する為のactionSaveImageButton
+    @IBAction private func actionSaveImageButton(_ sender: Any) {
+        //現在表示中の画像データを取得
+        let image = imageView.image
+        
+        //imageが空の場合には後続処理を継続しない
+        guard let thisImage = image else {
+            return
+        }
+        
+        let imageData = thisImage.pngData()
+        
+        //imageRowが空の場合には後続処理を継続しない
+        guard let thisImageRow = imageRow else {
+            return
+        }
+        
+        let stringImageRow = convertString(thisImageRow)
+        
+        //Keyに受け取ったRow、Valueに写真を指定して本体に収納
+        userDefaults.setValue(imageData, forKey: stringImageRow)
+        userDefaults.synchronize()
+    }
     //+ボタンを押下でカメラロールを開き、写真を選択
     @IBAction private func actionSelectImageButton(_ sender: Any) {
             //写真を選ぶビュー
@@ -57,8 +111,10 @@ extension DetailViewController: UIImagePickerControllerDelegate, UINavigationCon
         
         //選択された写真を取得
         let image = info[.originalImage] as! UIImage
-        //ビューに表示
+
+        //選択された写真を表示
         imageView.image = image
+        
         //写真を選ぶビューを閉じる
         self.dismiss(animated: true )
     }

--- a/StokManagementApp/StokManagementApp/ViewController.swift
+++ b/StokManagementApp/StokManagementApp/ViewController.swift
@@ -31,6 +31,9 @@ class ViewController: UIViewController {
     private var additionAmountValue: Int = 0
     //セグエで受け渡す変数
     private var sendText: String?
+    //セグエで受け渡すRownの変数
+    private var sendRow: Int?
+    private var myUITableCell = UITableViewCell()
 
     //MARK: - public method
     override func viewDidLoad() {
@@ -55,6 +58,12 @@ class ViewController: UIViewController {
             
             //detailVCのtitleTextにamountArrayを入れた変数を指定
             detailVC.titleText = sendText
+            
+            guard let thisSendRow = sendRow else {
+                return
+            }
+            
+            detailVC.imageRow = thisSendRow
         }
     }
     
@@ -252,7 +261,8 @@ extension ViewController : UITableViewDataSource, UITableViewDelegate {
             (ctxAction, view, completionHandler) in
             
             //sendTextに詳細ボタンが押された行に表示されているamountArrayの値を代入
-            self.sendText = self.amountArray[indexPath.row]            
+            self.sendText = self.amountArray[indexPath.row]
+            self.sendRow = indexPath.row
             self.performSegue(withIdentifier: "toDetailView", sender: nil)
             
             completionHandler(true)
@@ -266,9 +276,9 @@ extension ViewController : UITableViewDataSource, UITableViewDelegate {
             self.amountArray.remove(at: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .automatic)
             
-            //合計値をクリアして画面を再読み込み
-            self.additionAmountValue = 0
-            self.myUITable.reloadData()
+//            //合計値をクリアして画面を再読み込み
+//            self.additionAmountValue = 0
+//            self.myUITable.reloadData()
             
             completionHandler(true)
         }


### PR DESCRIPTION
DetailViewController.swift
・カメラロールで選択した写真をImageViewに表示する処理を実装
・userDefaultsで写真を本体に保存できるよう実装
・Saveボタンを押下で表示している写真を保存
・写真が保管されている行の詳細ボタンが押下されたら、その行に結びつけて保存してある写真を表示

ViewController.swift
・セグエで詳細ボタンを押下した行のIndexPathを受け渡し

Main.storyboard
・AutoLayoutを設定し、端末を変えても表示が崩れないようにした

変更量の多いプリクエストとなってしまいました。申し訳ございません。
お手数をおかけいたしますが、ご確認の程、よろしくお願いいたします。

<img width="378" alt="スクリーンショット 2020-05-20 17 50 53" src="https://user-images.githubusercontent.com/45379982/82428028-dbcaf400-9ac4-11ea-8d7d-e014b5a5551e.png">
<img width="982" alt="スクリーンショット 2020-05-20 17 52 32" src="https://user-images.githubusercontent.com/45379982/82428038-dff71180-9ac4-11ea-8b9f-4912b13ffa52.png">

