### PR TITLE
auto increment idの再利用防止の設定

### DIFF
--- a/StokManagementApp/StokManagementApp/StockModel.swift
+++ b/StokManagementApp/StokManagementApp/StockModel.swift
@@ -30,25 +30,34 @@ class StockModel: Object {
     }
     
     //インクリメントされたIDを持つ、新規StockModelオブジェクトを返す
-        static func create() -> StockModel {
-            let realm = try! Realm()
-            let stockModel = StockModel()
-            stockModel.id = newID(realm: realm)
-            return stockModel
+    static func create(asDummy: Bool = false) -> StockModel {
+        let realm = try! Realm()
+        if asDummy {
+            let newDummyStockModel = StockModel()
+            newDummyStockModel.id = StockModel.newID(realm: realm)
+            return newDummyStockModel
+        } else {
+            let lastID = (realm.objects(StockModel.self).sorted(byKeyPath: "id").last?.id)!
+            let dummyStockModel = realm.object(ofType: StockModel.self, forPrimaryKey: lastID)!
+            let newDummyStockModel = StockModel.create(asDummy: true)
+            try! realm.write {
+                realm.add(newDummyStockModel)
+            }
+            return dummyStockModel
+        }
     }
     
     //DBにデータを追加する為のaddStockDataメソッド
-    func addStockData(amount: Int, comment: String?, amountImage: Data?, createDate: String) -> StockModel {
+    func addStockData(amount: Int, comment: String?, amountImage: Data?, createDate: String) {
         let realm = try! Realm()
         let addStockData = StockModel.create()
-        addStockData.amount = amount
-        addStockData.comment = comment
-        addStockData.amountImage = amountImage
-        addStockData.createDate = createDate
         try! realm.write {
-            realm.add(addStockData)
+            addStockData.amount = amount
+            addStockData.comment = comment
+            addStockData.amountImage = amountImage
+            addStockData.createDate = createDate
         }
-        //printで確認するためにaddStockDataを返す
-        return addStockData
+        //DBに追加できているかの確認用
+        print(addStockData)
     }
 }

--- a/StokManagementApp/StokManagementApp/ViewController.swift
+++ b/StokManagementApp/StokManagementApp/ViewController.swift
@@ -47,6 +47,12 @@ class ViewController: UIViewController {
         self.tableView.delegate = self
         self.tableView.dataSource = self
         
+        //DB作成後、まずダミーオブジェクトを追加
+        let dummyStockModel = StockModel.create(asDummy: true)
+        try! realm.write {
+            realm.add(dummyStockModel)
+        }
+        
         //1秒毎にshowNowTimeメソッドを実行する
         Timer.scheduledTimer(timeInterval: 1,
                              target: self,
@@ -110,9 +116,9 @@ class ViewController: UIViewController {
         //カンマのついていない在庫数をinputAmountArrayに追加
         inputAmountArray.append(amount)
 
-        //DBにデータを追加（現在は追加できたかの確認のためにprintで出力）
-        print(stockModel.addStockData(amount: amount, comment: commentData, amountImage: nil, createDate: timeData))
-            
+        //DBにデータを追加
+        stockModel.addStockData(amount: amount, comment: commentData, amountImage: nil, createDate: timeData)
+    
         //追加ボタン押下で選択が全解除される為、一度sumAmountを初期化
         sumAmount = 0
         


### PR DESCRIPTION
StockModel.swift内、createメソッドをIDの再利用を防ぐ様に書き換えを実施。
ID再利用の設定を追加した結果createメソッドが大きくなってしまった為、addStockDetaメソッドとの統合はしないことにしました。
変更箇所におかしいところがないか、一度ご確認いただきたく存じます。

StockModel.swift
・auto increment IDが再利用されないよう設定
　→ダミーのオブジェクトをあらかじめ作成しておき、ダミーオブジェクトを書き換える形でデータの追加/更新を行う

ViewController.swift
・削除されたIDが再利用されない様、viewDidLoad内でダミーオブジェクトを作成する様にした。